### PR TITLE
Add a page with names of cats in custody

### DIFF
--- a/components/CatNames.js
+++ b/components/CatNames.js
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 export default function CatNames({ cats }) {
   const [nameFilter, setNameFilter] = useState('');
-  const [skipTemporary, setSkipTemporary] = useState(false);
 
   const uniqueNames = [...new Set(cats.map(({ Name }) => Name))];
   const lowercaseNameFilter = nameFilter.toLowerCase();
@@ -15,11 +14,8 @@ export default function CatNames({ cats }) {
       };
     })
     .filter(({ name, lowercaseName }) => {
-      if (name.match(/test|training|practice/i)) {
-        return false; // always skip test cats
-      }
-      if (skipTemporary && name.match(/[0-9]/i)) {
-        return false;
+      if (name.match(/test|training|practice|[0-9]/i)) {
+        return false; // always skip test cats and temporary names
       }
       if (nameFilter && !lowercaseName.includes(lowercaseNameFilter)) {
         return false;
@@ -34,26 +30,15 @@ export default function CatNames({ cats }) {
 
   return (
     <div className="p-4">
-      <div className="flex">
-        <div className="m-4 flex-1">
-          <input
-            class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-            id="nameFilterInput"
-            type="search"
-            value={nameFilter}
-            onChange={(e) => setNameFilter(e.target.value.trim())}
-            placeholder="Type to search..."
-          />
-        </div>
-        <div className="m-4 flex-1 self-center">
-          <input
-            id="skipTemporaryNames"
-            type="checkbox"
-            checked={skipTemporary}
-            onChange={(e) => setSkipTemporary(e.target.checked)}
-          />{' '}
-          <label htmlFor="skipTemporaryNames">Skip temporary names</label>
-        </div>
+      <div className="m-4">
+        <input
+          className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          id="nameFilterInput"
+          type="search"
+          value={nameFilter}
+          onChange={(e) => setNameFilter(e.target.value.trim())}
+          placeholder="Type to search..."
+        />
       </div>
       <hr />
       {namesToRender.length > 0 ? (

--- a/components/CatNames.js
+++ b/components/CatNames.js
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+export default function CatNames({ cats }) {
+  const [nameFilter, setNameFilter] = useState('');
+  const [skipTemporary, setSkipTemporary] = useState(false);
+
+  const uniqueNames = [...new Set(cats.map(({ Name }) => Name))];
+  const lowercaseNameFilter = nameFilter.toLowerCase();
+
+  const namesToRender = uniqueNames
+    .map((name) => {
+      return {
+        name,
+        lowercaseName: name.toLowerCase(),
+      };
+    })
+    .filter(({ name, lowercaseName }) => {
+      if (name.match(/test|training|practice/i)) {
+        return false; // always skip test cats
+      }
+      if (skipTemporary && name.match(/[0-9]/i)) {
+        return false;
+      }
+      if (nameFilter && !lowercaseName.includes(lowercaseNameFilter)) {
+        return false;
+      }
+      return true;
+    })
+    .sort((a, z) => {
+      return a.lowercaseName.localeCompare(z.lowercaseName);
+    });
+
+  const columnStyle = namesToRender.length > 20 ? { columns: '16rem auto' } : undefined;
+
+  return (
+    <div className="p-4">
+      <div className="flex">
+        <div className="m-4 flex-1">
+          <input
+            class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="nameFilterInput"
+            type="search"
+            value={nameFilter}
+            onChange={(e) => setNameFilter(e.target.value.trim())}
+            placeholder="Type to search..."
+          />
+        </div>
+        <div className="m-4 flex-1 self-center">
+          <input
+            id="skipTemporaryNames"
+            type="checkbox"
+            checked={skipTemporary}
+            onChange={(e) => setSkipTemporary(e.target.checked)}
+          />{' '}
+          <label htmlFor="skipTemporaryNames">Skip temporary names</label>
+        </div>
+      </div>
+      <hr />
+      {namesToRender.length > 0 ? (
+        <ul className="m-4" style={columnStyle}>
+          {namesToRender.map(({ name }) => (
+            <li key={name}>{name}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="m-4">No cats!</p>
+      )}
+    </div>
+  );
+}

--- a/config/api.js
+++ b/config/api.js
@@ -1,4 +1,3 @@
-const FETCH_URL =
-  "https://www.shelterluv.com/api/v1/animals?status_type=publishable";
+const FETCH_URL = 'https://www.shelterluv.com/api/v1/animals';
 
 export default FETCH_URL;

--- a/lib/api.js
+++ b/lib/api.js
@@ -15,12 +15,12 @@ export async function fetcher(url) {
   return json;
 }
 
-export async function fetchCats(url) {
+export async function fetchCats(url, status = '') {
   let records = 100,
     offset = 0,
     cats = [];
   while (records === 100) {
-    let res = await fetcher(`${url}&limit=100&offset=${offset}`);
+    let res = await fetcher(`${url}?limit=100&offset=${offset}&status_type=${status}`);
     cats.push(...res.animals);
     records = res.animals.length;
     offset += 100;
@@ -51,7 +51,13 @@ export function sanitizeCats(cats) {
 }
 
 export async function returnCats() {
-  const dirtyCats = await fetchCats(FETCH_URL);
+  const dirtyCats = await fetchCats(FETCH_URL, 'publishable');
+  const cats = await sanitizeCats(dirtyCats);
+  return cats;
+}
+
+export async function returnCatsInCustody() {
+  const dirtyCats = await fetchCats(FETCH_URL, 'in%20custody');
   const cats = await sanitizeCats(dirtyCats);
   return cats;
 }

--- a/pages/names.js
+++ b/pages/names.js
@@ -1,0 +1,16 @@
+import { returnCatsInCustody } from '../lib/api';
+import CatNames from '../components/CatNames';
+
+export async function getStaticProps() {
+  const cats = await returnCatsInCustody();
+  return {
+    props: {
+      cats,
+    },
+    revalidate: 300,
+  };
+}
+
+export default function CatNamesPage({ cats }) {
+  return <CatNames cats={cats} />;
+}


### PR DESCRIPTION
This PR adds a page that shows names of all cats that are currently in custody, so that fosters and volunteers could quickly check which names are already taken when naming a new cat.

![Oct-17-2021 19-37-25](https://user-images.githubusercontent.com/632081/137661782-087d0eec-5a81-4b71-83fb-e88b58b0bbb0.gif)

The page is not visible to normal people but should be accessible by direct link. My plan is to show this page to VOKRA team first, and if they like it then add a direct link to this page to foster website, or consider some other means of embedding it there.
